### PR TITLE
Vanilla Fishing Expanded - Fixed csproj and removed binary

### DIFF
--- a/Source/Mods/VanillaFishingExpanded.cs
+++ b/Source/Mods/VanillaFishingExpanded.cs
@@ -1,0 +1,18 @@
+﻿using Harmony;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>VanillaCuisineExpanded-Fishing by juanosarg</summary>
+    /// <see href="https://github.com/juanosarg/VanillaCuisineExpanded-Fishing"/>
+    /// contribution to Multiplayer Compatibility by Cody Spring
+    [MpCompatFor("Vanilla Fishing Expanded")]
+    class VanillaFishingExpanded
+    {
+        public VanillaFishingExpanded(ModContentPack mod)
+        {
+            MP.RegisterSyncMethod(AccessTools.Method("VCE_Fishing.JobDriver_Fish:SelectFishToCatch"));
+        }
+    }
+}

--- a/Source/Multiplayer_Compat.csproj
+++ b/Source/Multiplayer_Compat.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Mods\GiddyUpRideAndRoll.cs" />
     <Compile Include="Mods\GiddyUpBattleMounts.cs" />
     <Compile Include="Mods\GeneticRim.cs" />
+    <Compile Include="Mods\VanillaFishingExpanded.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Mods\" />


### PR DESCRIPTION
Added support for Vanilla Fishing Expanded by Sarg Bjornson and Oskar Potocki, found here:
https://steamcommunity.com/sharedfiles/filedetails/?id=1914064942

Tested by having 10 colonists fish for all types of fish for a week, fishing nothing but random "special loot" for a week, as well as cooking 2 75-stacks of each fish type. No desyncs on multiplayer LAN compared to very quickly desyncing without patch.

Binary removed and csproj file fixed