### PR TITLE
Add a PatchingUtilites method to "seed" Verse.Rand calls when useful

### DIFF
--- a/Source/Mods/FollowMe.cs
+++ b/Source/Mods/FollowMe.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using Multiplayer.API;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Misc. Robots by HaploX1</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=724602224"/>
+    [MpCompatFor("Fluffy.FollowMe")]
+    class FollowMe
+    {
+        public FollowMe(ModContentPack mod) => LongEventHandler.ExecuteWhenFinished(LatePatch);
+        private static void LatePatch()
+        {
+            PatchingUtilities.SeedVerseRand("FollowMe.CinematicCamera:FollowNewSubject");
+        }
+    }
+}


### PR DESCRIPTION
Hi,

  So I implemented a new transpiler and associated methods (mimicking the existing ones) to "seed" all "seedable" `Verse.Rand` calls in a method, using `Find.TickManager.TicksAbs` as the seed. For example, `Verse.Rand.Range(x,y)` becomes `Verse.Rand.Range(x,y,Find.TickManager.TicksAbs)`.
    I listed all such methods I found, that is : Chance(float), RangeInclusive(int,int), Range(float,float), Range(int, int), Value(). If there are more, please tell me, and I'll add them. (I know nothing about decompiling and stuff. Those are the ones I saw with Visual Studio's "MetaData" feature.)

  And I used this to patch the mod "FollowMe". It allows the user to follow a pawn with its camera, and features a Cinematic Camera, randomly choosing new targets. The random call in this feature caused desync, and this patch solves this.

Thanks !